### PR TITLE
Replace tycho-specific launcher icon path with copying the icon during build

### DIFF
--- a/tychodemo.product/pom.xml
+++ b/tychodemo.product/pom.xml
@@ -13,6 +13,9 @@
   <artifactId>tychodemo.product</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-repository</packaging>
+  <properties>
+    <product-id>tychodemo.product</product-id>
+  </properties>
   <build>
     <plugins>
       <plugin>
@@ -40,11 +43,32 @@
         <configuration>
           <products>
             <product>
-              <id>tychodemo.product</id>
+              <id>${product-id}</id>
               <rootFolder>myRCP</rootFolder>
             </product>
           </products>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.5</version>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/products/${product-id}\icons</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>icons</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/tychodemo.product/tychodemo.product
+++ b/tychodemo.product/tychodemo.product
@@ -22,9 +22,9 @@
       
    <launcher name="myRCP">
       <solaris/>
-      <linux icon="../../../icons/alt_launcher.xpm"/>
+      <linux icon="icons/alt_launcher.xpm"/>
       <win useIco="true">
-         <ico path="../../../icons/alt_launcher.ico"/>
+         <ico path="icons/alt_launcher.ico"/>
          <bmp/>
       </win>
    </launcher>


### PR DESCRIPTION
Hello,

currently the launcher icon path is specific for tycho,
when exporting the product using PDE the launcher icon is not replaced.

IMHO it is better to have the path so that you can export from within PDE
since this project is frequently used as an example project
and RCP applications are probably developed using PDE.

To make it work for Tycho the icon can be copied using the maven-resources-plugin during the build.

The changes i made do just that.

Regards,
Davy
