### PR TITLE
New Tycho version and encoding issues

### DIFF
--- a/tychodemo.parent/pom.xml
+++ b/tychodemo.parent/pom.xml
@@ -14,7 +14,7 @@
   </prerequisites>
 
   <properties>
-    <tycho-version>0.14.1</tycho-version>
+    <tycho-version>0.22.0</tycho-version>
   </properties>
   <repositories>
     <!-- configure p2 repository to resolve against -->

--- a/tychodemo.parent/pom.xml
+++ b/tychodemo.parent/pom.xml
@@ -15,6 +15,7 @@
 
   <properties>
     <tycho-version>0.22.0</tycho-version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <repositories>
     <!-- configure p2 repository to resolve against -->


### PR DESCRIPTION
Hello,

I just saw that this demo is often referenced in the tycho mailing-list and at least Jeremie Bresson complained that still version 0.14.1 is used here.
Therefore I updated the version and also the encoding, which previously has caused this warning: "[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!"

Best regards,

Simon